### PR TITLE
Support automated invalidation of CloudFront distro; make cfn-lint clean

### DIFF
--- a/modules/webhosting/README.md
+++ b/modules/webhosting/README.md
@@ -2,7 +2,9 @@
 
 **Purpose:** Instructions for hosting the website and creating a pipeline that automatically builds new static html files and uploads them to the appropriate S3 Bucket.
 
-1. Edit and deploy the CloudFront site in cloudfront-s3-website.yaml.  You should only need to change the parameter for WorkshopHostname.  Once that is complete run a command similar to the following but change the stackname
+### 1. Edit and deploy the CloudFront site in cloudfront-s3-website.yaml.  
+
+You should only need to change the parameter for WorkshopHostname.  Once that is complete run a command similar to the following but change the stackname
 
 > Stack takes about 20 minutes
 ```
@@ -10,7 +12,9 @@
 aws cloudformation create-stack --stack-name MY-Workshop --template-body file://cloudfront-s3-website.yaml
 ```
 
-2. Edit and deploy the pipeline in pipeline.yaml.  In this one you will probably want to change the first 4 parameters.  ProjectName should match whatever you put for WorkshopHostname in the cloudfront-s3-website.yaml.
+### 2. Edit and deploy the pipeline in pipeline.yaml.  
+
+In this one you will probably want to change the first 5 parameters.  ProjectName should match whatever you put for WorkshopHostname in the cloudfront-s3-website.yaml. Set the `CloudFrontDistroId` to the distribution ID generated from the first stack.
 
 > Stack completes in about 1-2 minutes  
 ```
@@ -18,4 +22,4 @@ aws cloudformation create-stack --stack-name MY-Workshop --template-body file://
 aws cloudformation create-stack --stack-name MY-Website-Pipeline --template-body file://pipeline.yaml --capabilities CAPABILITY_NAMED_IAM
 ```
 
-If you check the Build Pipeline and Build logs you should see files successfully copied to your S3 bucket.  
+If you check the Build Pipeline and Build logs you should see files successfully copied to your S3 bucket.

--- a/modules/webhosting/cloudfront-s3-website.yaml
+++ b/modules/webhosting/cloudfront-s3-website.yaml
@@ -32,7 +32,6 @@ Resources:
     
   WebsiteBucketPolicy:
     Type: AWS::S3::BucketPolicy
-    DependsOn: WebsiteBucket
     Properties:
       Bucket: !Ref 'WebsiteBucket'
       PolicyDocument:
@@ -45,8 +44,6 @@ Resources:
           
   WebsiteCloudFront:
     Type: AWS::CloudFront::Distribution
-    DependsOn:
-    - WebsiteBucket
     Properties:
       DistributionConfig:
         Comment: !Join [' ', [!Ref 'WebsiteBucket', "Workshop Distribution"]]
@@ -81,7 +78,6 @@ Resources:
         
   WebsiteDNSName:
     Type: AWS::Route53::RecordSet
-    DependsOn: WebsiteCloudFront
     Properties:
       AliasTarget:
         DNSName: !GetAtt WebsiteCloudFront.DomainName
@@ -94,6 +90,9 @@ Outputs:
   BucketName:
     Value: !Ref 'WebsiteBucket'
     Description: Name of S3 bucket to hold website content
+  CloudFrontDistroId:
+    Value: !Ref WebsiteCloudFront
+    Description: CloudFront distribution ID
   CloudfrontEndpoint:
     Value: !GetAtt [WebsiteCloudFront, DomainName]
     Description: Endpoint for CloudFront distribution

--- a/modules/webhosting/pipeline.yaml
+++ b/modules/webhosting/pipeline.yaml
@@ -126,8 +126,10 @@ Resources:
             Value: !Ref AWS::Region
           - Name: FULL_REPO_URL
             Value: !Ref FullRepoURL
-          - Name: WEB_SITE_BUCKET  
-            Value: !Ref WebsiteBucket  
+          - Name: WEB_SITE_BUCKET
+            Value: !Ref WebsiteBucket
+          - Name: CLOUDFRONT_DISTRO_ID
+            Value: !Ref CloudFrontDistroId
         PrivilegedMode: true
       Name: !Join ['', [!Ref 'ProjectName', '-Workshop-website']]
       ServiceRole: !Ref CodeBuildServiceRole

--- a/modules/webhosting/pipeline.yaml
+++ b/modules/webhosting/pipeline.yaml
@@ -2,8 +2,11 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: This template will launch the Modernization Workshop CI/CD Pipeline.
 
 # It should only be necessary to update the parameters
-# run this stack as below but sub for {WORKSHOP NAME} with the workshop/company name
+# run this stack as below but sub for {WORKSHOP NAME} with the workshop/company name and set the value
+# of CloudFrontDistroId resulting from the S3 + CloudFront CloudFormation template.
+
 # aws cloudformation create-stack --stack-name {WORKSHOP NAME}-Website-Pipeline --template-body file://pipeline.yaml --capabilities CAPABILITY_NAMED_IAM
+
 Parameters:
   ProjectName:
     Type: String
@@ -12,7 +15,11 @@ Parameters:
   WebsiteBucket:
     Type: String
     Description: Website S3 bucket name
-    Default: xxxxxxx.modernize.awsworkshop.io  
+    Default: xxxxxxx.awsworkshop.io 
+  CloudFrontDistroId:
+    Type: String
+    Description: CloudFront distribution ID 
+    Default: yyyyyyy
   GitHubRepo:
     Type: String
     Description: repo name
@@ -62,6 +69,10 @@ Resources:
                   - s3:PutObject
                   - s3:GetObjectVersion
                   - s3:ListBucket
+              - Effect: Allow
+                Action:
+                  - cloudfront:CreateInvalidation
+                Resource: !Sub arn:aws:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistroId}
 
   CodePipelineServiceRole:
     Type: AWS::IAM::Role
@@ -135,7 +146,7 @@ Resources:
               ActionTypeId:
                 Category: Source
                 Owner: ThirdParty
-                Version: 1
+                Version: '1'
                 Provider: GitHub
               Configuration:
                 Owner: !Ref GitHubOwner
@@ -152,7 +163,7 @@ Resources:
               ActionTypeId:
                 Category: Build
                 Owner: AWS
-                Version: 1
+                Version: '1'
                 Provider: CodeBuild
               Configuration:
                 ProjectName: !Ref CodeBuildProject
@@ -168,7 +179,7 @@ Resources:
       Authentication: GITHUB_HMAC
       AuthenticationConfiguration:
         SecretToken: '{{resolve:secretsmanager:GitHub/WorkshopOwnerToken:SecretString:OwnerToken}}'
-      RegisterWithThirdParty: 'true'
+      RegisterWithThirdParty: true
       Filters:
       - JsonPath: "$.ref"
         MatchEquals: refs/heads/{Branch}

--- a/webspec.yml
+++ b/webspec.yml
@@ -31,4 +31,5 @@ phases:
       - ./hugo -D
       - echo Deploy Copy Website to S3 Bucket
       - aws s3 cp public/ s3://${WEB_SITE_BUCKET}/ --recursive
+      - aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_DISTRO_ID} --paths /\*
       


### PR DESCRIPTION
* Support automated invalidation of CloudFront distro.
* Remove `modernization` from example FQDN.
* Make cfn-lint clean.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
