### PR TITLE
Add command to delete AWS remote origin

### DIFF
--- a/hugo-docs-content/20_build/1_setup.md
+++ b/hugo-docs-content/20_build/1_setup.md
@@ -39,7 +39,11 @@ The submodules contain the hugo-theme-learn theme for the Hugo Framework.
 
 ## 3. Create and push to YOUR GitHub repo
 
-**Create a repo in your GitHub account and follow the instructions under "Push an existing repository from the command line"**
+To make sure you won't face a remote repo name conflict in your project, first remove the existing remote `origin`:
+```
+git remote rm origin
+```
+Then, create a repo in your GitHub account and follow the instructions under "Push an existing repository from the command line":
 
 ## 4. Install Hugo
 If you're using a Mac, go to your terminal:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Without first removing the AWS origin, you'd run into `fatal: remote origin already exists` - this is a suggestion for a quick & dirty fix.

Have an excellent rest of your day 😃 

cc @jamesbland123

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
